### PR TITLE
HM-699 - Add clearKeychainData method to iOS Firebase plugin and Java…

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ To help ensure this plugin is kept updated, new features are added and bugfixes 
     - [signOutUser](#signoutuser)
     - [getUserFromSharedKeychain](#getuserfromsharedkeychain)
     - [signInWithSharedKeychainUser](#signinwithsharedkeychainuser)
+    - [clearKeychainData](#clearkeychaindata)
     - [getCurrentUser](#getcurrentuser)
     - [reloadCurrentUser](#reloadcurrentuser)
     - [updateUserProfile](#updateuserprofile)
@@ -2275,6 +2276,9 @@ Checks whether there is a user in the shared keychain access group. If yes, retu
 
 ### signInWithSharedKeychainUser
 Signs in with the user in the shared keychain access group.
+
+### clearKeychainData
+Clears the keychain data for the current user.
 
 ### getCurrentUser
 Returns details of the currently logged in user from local Firebase SDK.

--- a/src/ios/FirebasePlugin.h
+++ b/src/ios/FirebasePlugin.h
@@ -35,6 +35,7 @@
 - (void)reauthenticateWithCredential:(CDVInvokedUrlCommand*)command;
 - (void)isUserSignedIn:(CDVInvokedUrlCommand*)command;
 - (void)signOutUser:(CDVInvokedUrlCommand*)command;
+- (void)clearKeychainData:(CDVInvokedUrlCommand*)command;
 - (void)getUserFromSharedKeychain:(CDVInvokedUrlCommand*)command;
 - (void)signInWithSharedKeychainUser:(CDVInvokedUrlCommand*)command;
 - (void)getCurrentUser:(CDVInvokedUrlCommand*)command;

--- a/src/ios/FirebasePlugin.m
+++ b/src/ios/FirebasePlugin.m
@@ -923,6 +923,34 @@ static NSMutableDictionary* traces;
     }
 }
 
+- (void)clearKeychainData:(CDVInvokedUrlCommand*)command {
+    @try {
+        NSLog(@"[clearKeychainData] Starting keychain clean process...");
+
+        NSString *sharedKeychainAccessGroup = @"APU8L33GKN.com.huckleberry-labs.app";
+        NSLog(@"[clearKeychainData] Using shared keychain group: %@", sharedKeychainAccessGroup);
+        
+        [FIRAuth.auth useUserAccessGroup:sharedKeychainAccessGroup error:nil];
+        
+        FIRUser *sharedUser = [[FIRAuth auth] currentUser];
+        if (sharedUser) {
+            NSLog(@"[clearKeychainData] Found user in shared keychain, clearing...");
+            [[FIRAuth auth] signOut:nil];
+        } else {
+            NSLog(@"[clearKeychainData] No user found in shared keychain");
+        }
+
+        AppDelegate *AppDelegateInstance = [[AppDelegate alloc] init];
+        NSString *defaultKeyChainAccessGroup = [AppDelegateInstance keychainAccessGroup];
+        [FIRAuth.auth useUserAccessGroup:defaultKeyChainAccessGroup error:nil];
+      
+        [self sendPluginSuccess:command];
+    }@catch (NSException *exception) {
+        NSLog(@"[clearKeychainData] Exception occurred: %@", exception);
+        [self handlePluginExceptionWithContext:exception :command];
+    }
+}
+
 - (void)getUserFromSharedKeychain:(CDVInvokedUrlCommand *)command {
     @try {
         NSError *error = nil;

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -334,6 +334,10 @@ exports.getUserFromSharedKeychain = function (success, error) {
   }, error, "FirebasePlugin", "getUserFromSharedKeychain", []);
 };
 
+exports.clearKeychainData = function (success, error) {
+    exec(success, error, "FirebasePlugin", "clearKeychainData", []);
+};
+
 exports.signInWithSharedKeychainUser = function (success, error) {
   exec(success, error, "FirebasePlugin", "signInWithSharedKeychainUser");
 };


### PR DESCRIPTION
Added the `clearKeychainData` method to plugin to enable clear keychain data from the shared group. 
Updated the `FirebasePlugin.h` and `FirebasePlugin.m` files.
Added JS function in `firebase.js`.