### PR TITLE
Get idToken reworked

### DIFF
--- a/src/ios/FirebasePlugin.h
+++ b/src/ios/FirebasePlugin.h
@@ -41,7 +41,7 @@
 - (void)getCurrentUser:(CDVInvokedUrlCommand*)command;
 - (void)reloadCurrentUser:(CDVInvokedUrlCommand*)command;
 - (void)getIdToken:(CDVInvokedUrlCommand*)command;
-- (void)getIdTokenWithoutRefresh:(CDVInvokedUrlCommand*)command;
+- (void)getIdTokenForcingRefresh:(CDVInvokedUrlCommand*)command;
 - (void)updateUserProfile:(CDVInvokedUrlCommand*)command;
 - (void)updateUserEmail:(CDVInvokedUrlCommand*)command;
 - (void)sendUserEmailVerification:(CDVInvokedUrlCommand*)command;

--- a/www/firebase.js
+++ b/www/firebase.js
@@ -372,8 +372,8 @@ exports.getIdToken = function (success, error) {
     exec(success, error, "FirebasePlugin", "getIdToken", []);
 };
 
-exports.getIdTokenWithoutRefresh = function (success, error) {
-    exec(success, error, "FirebasePlugin", "getIdTokenWithoutRefresh", []);
+exports.getIdTokenForcingRefresh = function (success, error) {
+    exec(success, error, "FirebasePlugin", "getIdTokenForcingRefresh", []);
 };
 
 exports.sendUserEmailVerification = function (success, error) {


### PR DESCRIPTION
- Fixes double token request in getIdToken
- Fixes return of outdated token in result of -(void)getIdToken 
- Method -(void)getIdToken doesn't force to refresh token.
- Method -(void)getIdTokenWithoutRefresh was replaced with -(void)getIdTokenForcingRefresh.